### PR TITLE
Updated deprecated policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ The ECS Cluster nodes need to have an instance profile attached that allows them
 These are all AWS managed policies so we only need to add the role.
 Create new `EcsInstanceRole` IAM role, select `AWS Service` -> `EC2` as Trusted Entity. Attach following permissions policies:
 
-  - AmazonEC2RoleforSSM
+  - AmazonSSMManagedInstanceCore
   - AmazonEC2ContainerServiceforEC2Role
   - AWSLambdaBasicExecutionRole
 


### PR DESCRIPTION
*Issue #, if available:* #6

*Description of changes:* updated documentation, SSM policy for `EcsInstanceRole`, changed from  the deprecated `AmazonEC2RoleforSSM` to`AmazonSSMManagedInstanceCore`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
